### PR TITLE
Update to a scalatest version that is compatible with 2.11 and 2.12

### DIFF
--- a/enrich-points-with-boundaries/geodatabase/build.gradle
+++ b/enrich-points-with-boundaries/geodatabase/build.gradle
@@ -17,19 +17,24 @@ dependencies {
 
 	testImplementation "org.apache.spark:spark-core_$scala_version:$spark_version"
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
-	testImplementation "org.scalatest:scalatest_$scala_version:2.2.6"
-	testImplementation 'junit:junit:4.12'
+	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
+	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
 }
+
+task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
+	main = 'org.scalatest.tools.Runner'
+	args = ['-R', 'build/classes/scala/test', '-o']
+	classpath = sourceSets.test.runtimeClasspath
+	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
+	maxHeapSize = "2560m"
+}
+test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {File f -> f.name.contains("scalatest")}.getSingleFile()) //adding scalatest for assertions
-}
-
-tasks.withType(Test) {
-	//set Hadoop binary lib for windows
-	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
-	maxHeapSize = "2560m"
+	from zipTree(configurations.testRuntimeClasspath.filter {
+		File f -> f.name.contains("scalatest-core_${scala_version}")
+	}.getSingleFile()) //adding scalatest for assertions
 }

--- a/enrich-points-with-boundaries/geodatabase/build.gradle
+++ b/enrich-points-with-boundaries/geodatabase/build.gradle
@@ -19,22 +19,22 @@ dependencies {
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
 	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
 	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
+	testImplementation "org.scalatestplus:junit-4-13_$scala_version:3.2.2.0"
+	testImplementation "junit:junit:4.13"
 }
 
-task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
-	main = 'org.scalatest.tools.Runner'
-	args = ['-R', 'build/classes/scala/test', '-o']
-	classpath = sourceSets.test.runtimeClasspath
+tasks.withType(Test) {
+	//set Hadoop binary lib for windows
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 	maxHeapSize = "2560m"
 }
-test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {
-		File f -> f.name.contains("scalatest-core_${scala_version}")
-	}.getSingleFile()) //adding scalatest for assertions
+	//adding scalatest for assertions
+	["scalatest-core_${scala_version}", "scalactic_${scala_version}", "scalatest-compatible"].each { lib ->
+		from zipTree(configurations.testRuntimeClasspath.filter{ it.name.contains(lib) }.getSingleFile())
+	}
 }

--- a/enrich-points-with-boundaries/geodatabase/src/test/scala/com/precisely/bigdata/sample/spark/GeodatabaseEnrichmentTester.scala
+++ b/enrich-points-with-boundaries/geodatabase/src/test/scala/com/precisely/bigdata/sample/spark/GeodatabaseEnrichmentTester.scala
@@ -15,12 +15,10 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
 
-@RunWith(classOf[JUnitRunner])
-class GeodatabaseEnrichmentTester extends FunSuite with BeforeAndAfterAll {
+class GeodatabaseEnrichmentTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 
   override def beforeAll() {

--- a/enrich-points-with-boundaries/geodatabase/src/test/scala/com/precisely/bigdata/sample/spark/GeodatabaseEnrichmentTester.scala
+++ b/enrich-points-with-boundaries/geodatabase/src/test/scala/com/precisely/bigdata/sample/spark/GeodatabaseEnrichmentTester.scala
@@ -15,9 +15,12 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
+import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class GeodatabaseEnrichmentTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 

--- a/enrich-points-with-boundaries/shape/build.gradle
+++ b/enrich-points-with-boundaries/shape/build.gradle
@@ -17,19 +17,24 @@ dependencies {
 
 	testImplementation "org.apache.spark:spark-core_$scala_version:$spark_version"
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
-	testImplementation "org.scalatest:scalatest_$scala_version:2.2.6"
-	testImplementation 'junit:junit:4.12'
+	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
+	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
 }
+
+task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
+	main = 'org.scalatest.tools.Runner'
+	args = ['-R', 'build/classes/scala/test', '-o']
+	classpath = sourceSets.test.runtimeClasspath
+	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
+	maxHeapSize = "2560m"
+}
+test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {File f -> f.name.contains("scalatest")}.getSingleFile()) //adding scalatest for assertions
-}
-
-tasks.withType(Test) {
-	//set Hadoop binary lib for windows
-	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
-	maxHeapSize = "2560m"
+	from zipTree(configurations.testRuntimeClasspath.filter {
+		File f -> f.name.contains("scalatest-core_${scala_version}")
+	}.getSingleFile()) //adding scalatest for assertions
 }

--- a/enrich-points-with-boundaries/shape/build.gradle
+++ b/enrich-points-with-boundaries/shape/build.gradle
@@ -19,22 +19,22 @@ dependencies {
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
 	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
 	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
+	testImplementation "org.scalatestplus:junit-4-13_$scala_version:3.2.2.0"
+	testImplementation "junit:junit:4.13"
 }
 
-task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
-	main = 'org.scalatest.tools.Runner'
-	args = ['-R', 'build/classes/scala/test', '-o']
-	classpath = sourceSets.test.runtimeClasspath
+tasks.withType(Test) {
+	//set Hadoop binary lib for windows
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 	maxHeapSize = "2560m"
 }
-test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {
-		File f -> f.name.contains("scalatest-core_${scala_version}")
-	}.getSingleFile()) //adding scalatest for assertions
+	//adding scalatest for assertions
+	["scalatest-core_${scala_version}", "scalactic_${scala_version}", "scalatest-compatible"].each { lib ->
+		from zipTree(configurations.testRuntimeClasspath.filter{ it.name.contains(lib) }.getSingleFile())
+	}
 }

--- a/enrich-points-with-boundaries/shape/src/test/scala/com/precisely/bigdata/sample/spark/ShapeEnrichmentTester.scala
+++ b/enrich-points-with-boundaries/shape/src/test/scala/com/precisely/bigdata/sample/spark/ShapeEnrichmentTester.scala
@@ -15,9 +15,12 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
+import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class ShapeEnrichmentTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 

--- a/enrich-points-with-boundaries/shape/src/test/scala/com/precisely/bigdata/sample/spark/ShapeEnrichmentTester.scala
+++ b/enrich-points-with-boundaries/shape/src/test/scala/com/precisely/bigdata/sample/spark/ShapeEnrichmentTester.scala
@@ -15,12 +15,10 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
 
-@RunWith(classOf[JUnitRunner])
-class ShapeEnrichmentTester extends FunSuite with BeforeAndAfterAll {
+class ShapeEnrichmentTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 
   override def beforeAll() {

--- a/enrich-points-with-boundaries/tab/build.gradle
+++ b/enrich-points-with-boundaries/tab/build.gradle
@@ -17,19 +17,24 @@ dependencies {
 
 	testImplementation "org.apache.spark:spark-core_$scala_version:$spark_version"
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
-	testImplementation "org.scalatest:scalatest_$scala_version:2.2.6"
-	testImplementation 'junit:junit:4.12'
+	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
+	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
 }
+
+task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
+	main = 'org.scalatest.tools.Runner'
+	args = ['-R', 'build/classes/scala/test', '-o']
+	classpath = sourceSets.test.runtimeClasspath
+	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
+	maxHeapSize = "2560m"
+}
+test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {File f -> f.name.contains("scalatest")}.getSingleFile()) //adding scalatest for assertions
-}
-
-tasks.withType(Test) {
-	//set Hadoop binary lib for windows
-	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
-	maxHeapSize = "2560m"
+	from zipTree(configurations.testRuntimeClasspath.filter {
+		File f -> f.name.contains("scalatest-core_${scala_version}")
+	}.getSingleFile()) //adding scalatest for assertions
 }

--- a/enrich-points-with-boundaries/tab/build.gradle
+++ b/enrich-points-with-boundaries/tab/build.gradle
@@ -19,22 +19,22 @@ dependencies {
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
 	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
 	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
+	testImplementation "org.scalatestplus:junit-4-13_$scala_version:3.2.2.0"
+	testImplementation "junit:junit:4.13"
 }
 
-task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
-	main = 'org.scalatest.tools.Runner'
-	args = ['-R', 'build/classes/scala/test', '-o']
-	classpath = sourceSets.test.runtimeClasspath
+tasks.withType(Test) {
+	//set Hadoop binary lib for windows
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 	maxHeapSize = "2560m"
 }
-test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {
-		File f -> f.name.contains("scalatest-core_${scala_version}")
-	}.getSingleFile()) //adding scalatest for assertions
+	//adding scalatest for assertions
+	["scalatest-core_${scala_version}", "scalactic_${scala_version}", "scalatest-compatible"].each { lib ->
+		from zipTree(configurations.testRuntimeClasspath.filter{ it.name.contains(lib) }.getSingleFile())
+	}
 }

--- a/enrich-points-with-boundaries/tab/src/test/scala/com/precisely/bigdata/sample/spark/TABEnrichmentTester.scala
+++ b/enrich-points-with-boundaries/tab/src/test/scala/com/precisely/bigdata/sample/spark/TABEnrichmentTester.scala
@@ -15,9 +15,12 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
+import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class TABEnrichmentTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 

--- a/enrich-points-with-boundaries/tab/src/test/scala/com/precisely/bigdata/sample/spark/TABEnrichmentTester.scala
+++ b/enrich-points-with-boundaries/tab/src/test/scala/com/precisely/bigdata/sample/spark/TABEnrichmentTester.scala
@@ -15,12 +15,10 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
 
-@RunWith(classOf[JUnitRunner])
-class TABEnrichmentTester extends FunSuite with BeforeAndAfterAll {
+class TABEnrichmentTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 
   override def beforeAll() {

--- a/enrich-points-with-boundaries/using-schema/build.gradle
+++ b/enrich-points-with-boundaries/using-schema/build.gradle
@@ -17,19 +17,24 @@ dependencies {
 
 	testImplementation "org.apache.spark:spark-core_$scala_version:$spark_version"
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
-	testImplementation "org.scalatest:scalatest_$scala_version:2.2.6"
-	testImplementation 'junit:junit:4.12'
+	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
+	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
 }
+
+task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
+	main = 'org.scalatest.tools.Runner'
+	args = ['-R', 'build/classes/scala/test', '-o']
+	classpath = sourceSets.test.runtimeClasspath
+	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
+	maxHeapSize = "2560m"
+}
+test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {File f -> f.name.contains("scalatest")}.getSingleFile()) //adding scalatest for assertions
-}
-
-tasks.withType(Test) {
-	//set Hadoop binary lib for windows
-	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
-	maxHeapSize = "2560m"
+	from zipTree(configurations.testRuntimeClasspath.filter {
+		File f -> f.name.contains("scalatest-core_${scala_version}")
+	}.getSingleFile()) //adding scalatest for assertions
 }

--- a/enrich-points-with-boundaries/using-schema/build.gradle
+++ b/enrich-points-with-boundaries/using-schema/build.gradle
@@ -19,22 +19,22 @@ dependencies {
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
 	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
 	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
+	testImplementation "org.scalatestplus:junit-4-13_$scala_version:3.2.2.0"
+	testImplementation "junit:junit:4.13"
 }
 
-task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
-	main = 'org.scalatest.tools.Runner'
-	args = ['-R', 'build/classes/scala/test', '-o']
-	classpath = sourceSets.test.runtimeClasspath
+tasks.withType(Test) {
+	//set Hadoop binary lib for windows
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 	maxHeapSize = "2560m"
 }
-test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {
-		File f -> f.name.contains("scalatest-core_${scala_version}")
-	}.getSingleFile()) //adding scalatest for assertions
+	//adding scalatest for assertions
+	["scalatest-core_${scala_version}", "scalactic_${scala_version}", "scalatest-compatible"].each { lib ->
+		from zipTree(configurations.testRuntimeClasspath.filter{ it.name.contains(lib) }.getSingleFile())
+	}
 }

--- a/enrich-points-with-boundaries/using-schema/src/test/scala/com/precisely/bigdata/sample/spark/TABEnrichmentWithSchemaTester.scala
+++ b/enrich-points-with-boundaries/using-schema/src/test/scala/com/precisely/bigdata/sample/spark/TABEnrichmentWithSchemaTester.scala
@@ -15,12 +15,10 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
 
-@RunWith(classOf[JUnitRunner])
-class ShapeEnrichmentTester extends FunSuite with BeforeAndAfterAll {
+class TABEnrichmentWithSchemaTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 
   override def beforeAll() {

--- a/enrich-points-with-boundaries/using-schema/src/test/scala/com/precisely/bigdata/sample/spark/TABEnrichmentWithSchemaTester.scala
+++ b/enrich-points-with-boundaries/using-schema/src/test/scala/com/precisely/bigdata/sample/spark/TABEnrichmentWithSchemaTester.scala
@@ -15,9 +15,12 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
+import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class TABEnrichmentWithSchemaTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 

--- a/enrich-points-with-nearby-points/build.gradle
+++ b/enrich-points-with-nearby-points/build.gradle
@@ -22,18 +22,23 @@ dependencies {
 
 	testImplementation "org.apache.spark:spark-core_$scala_version:$spark_version"
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
-	testImplementation "org.scalatest:scalatest_$scala_version:2.2.6"
-	testImplementation 'junit:junit:4.12'
+	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
+	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
 }
 
-tasks.withType(Test) {
-	//set Hadoop binary lib for windows
+task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
+	main = 'org.scalatest.tools.Runner'
+	args = ['-R', 'build/classes/scala/test', '-o']
+	classpath = sourceSets.test.runtimeClasspath
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 }
+test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {File f -> f.name.contains("scalatest")}.getSingleFile()) //adding scalatest for assertions
+	from zipTree(configurations.testRuntimeClasspath.filter {
+		File f -> f.name.contains("scalatest-core_${scala_version}")
+	}.getSingleFile()) //adding scalatest for assertions
 }

--- a/enrich-points-with-nearby-points/build.gradle
+++ b/enrich-points-with-nearby-points/build.gradle
@@ -24,21 +24,21 @@ dependencies {
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
 	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
 	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
+	testImplementation "org.scalatestplus:junit-4-13_$scala_version:3.2.2.0"
+	testImplementation "junit:junit:4.13"
 }
 
-task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
-	main = 'org.scalatest.tools.Runner'
-	args = ['-R', 'build/classes/scala/test', '-o']
-	classpath = sourceSets.test.runtimeClasspath
+tasks.withType(Test) {
+	//set Hadoop binary lib for windows
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 }
-test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {
-		File f -> f.name.contains("scalatest-core_${scala_version}")
-	}.getSingleFile()) //adding scalatest for assertions
+	//adding scalatest for assertions
+	["scalatest-core_${scala_version}", "scalactic_${scala_version}", "scalatest-compatible"].each { lib ->
+		from zipTree(configurations.testRuntimeClasspath.filter{ it.name.contains(lib) }.getSingleFile())
+	}
 }

--- a/enrich-points-with-nearby-points/src/test/scala/com/precisely/bigdata/sample/spark/PointEnrichmentTester.scala
+++ b/enrich-points-with-nearby-points/src/test/scala/com/precisely/bigdata/sample/spark/PointEnrichmentTester.scala
@@ -15,9 +15,12 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
+import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class PointEnrichmentTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 

--- a/enrich-points-with-nearby-points/src/test/scala/com/precisely/bigdata/sample/spark/PointEnrichmentTester.scala
+++ b/enrich-points-with-nearby-points/src/test/scala/com/precisely/bigdata/sample/spark/PointEnrichmentTester.scala
@@ -15,12 +15,10 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
 
-@RunWith(classOf[JUnitRunner])
-class PointEnrichmentTester extends FunSuite with BeforeAndAfterAll {
+class PointEnrichmentTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 
   override def beforeAll() {

--- a/geohash-aggregation/build.gradle
+++ b/geohash-aggregation/build.gradle
@@ -22,18 +22,23 @@ dependencies {
 
 	testImplementation "org.apache.spark:spark-core_$scala_version:$spark_version"
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
-	testImplementation "org.scalatest:scalatest_$scala_version:2.2.6"
-	testImplementation 'junit:junit:4.12'
+	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
+	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
 }
 
-tasks.withType(Test) {
-	//set Hadoop binary lib for windows
+task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
+	main = 'org.scalatest.tools.Runner'
+	args = ['-R', 'build/classes/scala/test', '-o']
+	classpath = sourceSets.test.runtimeClasspath
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 }
+test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {File f -> f.name.contains("scalatest")}.getSingleFile()) //adding scalatest for assertions
+	from zipTree(configurations.testRuntimeClasspath.filter {
+		File f -> f.name.contains("scalatest-core_${scala_version}")
+	}.getSingleFile()) //adding scalatest for assertions
 }

--- a/geohash-aggregation/build.gradle
+++ b/geohash-aggregation/build.gradle
@@ -24,21 +24,21 @@ dependencies {
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
 	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
 	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
+	testImplementation "org.scalatestplus:junit-4-13_$scala_version:3.2.2.0"
+	testImplementation "junit:junit:4.13"
 }
 
-task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
-	main = 'org.scalatest.tools.Runner'
-	args = ['-R', 'build/classes/scala/test', '-o']
-	classpath = sourceSets.test.runtimeClasspath
+tasks.withType(Test) {
+	//set Hadoop binary lib for windows
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 }
-test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {
-		File f -> f.name.contains("scalatest-core_${scala_version}")
-	}.getSingleFile()) //adding scalatest for assertions
+	//adding scalatest for assertions
+	["scalatest-core_${scala_version}", "scalactic_${scala_version}", "scalatest-compatible"].each { lib ->
+		from zipTree(configurations.testRuntimeClasspath.filter{ it.name.contains(lib) }.getSingleFile())
+	}
 }

--- a/geohash-aggregation/src/test/scala/com/precisely/bigdata/sample/spark/GeohashAggregationTester.scala
+++ b/geohash-aggregation/src/test/scala/com/precisely/bigdata/sample/spark/GeohashAggregationTester.scala
@@ -15,9 +15,12 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
+import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class GeohashAggregationTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 

--- a/geohash-aggregation/src/test/scala/com/precisely/bigdata/sample/spark/GeohashAggregationTester.scala
+++ b/geohash-aggregation/src/test/scala/com/precisely/bigdata/sample/spark/GeohashAggregationTester.scala
@@ -15,12 +15,10 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
 
-@RunWith(classOf[JUnitRunner])
-class GeohashAggregationTester extends FunSuite with BeforeAndAfterAll {
+class GeohashAggregationTester extends AnyFunSuite with BeforeAndAfterAll {
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 
   override def beforeAll() {

--- a/multipass-geocoding/build.gradle
+++ b/multipass-geocoding/build.gradle
@@ -24,22 +24,22 @@ dependencies {
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
 	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
 	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
+	testImplementation "org.scalatestplus:junit-4-13_$scala_version:3.2.2.0"
+	testImplementation "junit:junit:4.13"
 	testImplementation "org.apache.commons:commons-lang3:3.4"
 }
 
-task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
-	main = 'org.scalatest.tools.Runner'
-	args = ['-R', 'build/classes/scala/test', '-o']
-	classpath = sourceSets.test.runtimeClasspath
+tasks.withType(Test) {
+	//set Hadoop binary lib for windows
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 }
-test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {
-		File f -> f.name.contains("scalatest-core_${scala_version}")
-	}.getSingleFile()) //adding scalatest for assertions
+	//adding scalatest for assertions
+	["scalatest-core_${scala_version}", "scalactic_${scala_version}", "scalatest-compatible"].each { lib ->
+		from zipTree(configurations.testRuntimeClasspath.filter{ it.name.contains(lib) }.getSingleFile())
+	}
 }

--- a/multipass-geocoding/build.gradle
+++ b/multipass-geocoding/build.gradle
@@ -22,19 +22,24 @@ dependencies {
 
 	testImplementation "org.apache.spark:spark-core_$scala_version:$spark_version"
 	testImplementation "org.apache.spark:spark-sql_$scala_version:$spark_version"
-	testImplementation "org.scalatest:scalatest_$scala_version:2.2.6"
-	testImplementation 'junit:junit:4.12'
+	testImplementation "org.scalatest:scalatest_$scala_version:3.2.2"
+	testImplementation "org.scalatest:scalatest-funsuite_$scala_version:3.2.2"
 	testImplementation "org.apache.commons:commons-lang3:3.4"
 }
 
-tasks.withType(Test) {
-	//set Hadoop binary lib for windows
+task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
+	main = 'org.scalatest.tools.Runner'
+	args = ['-R', 'build/classes/scala/test', '-o']
+	classpath = sourceSets.test.runtimeClasspath
 	systemProperty "hadoop.home.dir", "${project.rootDir}/hadoop-2.7.1"
 }
+test.dependsOn scalaTest
 
 //task to build jar that can run the verification on a cluster
 task testJar(type: Jar) {
 	archiveClassifier.set('tests-all')
 	from sourceSets.test.output
-	from zipTree(configurations.testRuntimeClasspath.filter {File f -> f.name.contains("scalatest")}.getSingleFile()) //adding scalatest for assertions
+	from zipTree(configurations.testRuntimeClasspath.filter {
+		File f -> f.name.contains("scalatest-core_${scala_version}")
+	}.getSingleFile()) //adding scalatest for assertions
 }

--- a/multipass-geocoding/src/test/scala/com/precisely/bigdata/sample/spark/MultipassGeocodingTester.scala
+++ b/multipass-geocoding/src/test/scala/com/precisely/bigdata/sample/spark/MultipassGeocodingTester.scala
@@ -15,12 +15,10 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
 
-@RunWith(classOf[JUnitRunner])
-class MultipassGeocodingTester extends FunSuite with BeforeAndAfterAll {
+class MultipassGeocodingTester extends AnyFunSuite with BeforeAndAfterAll {
 
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes
 

--- a/multipass-geocoding/src/test/scala/com/precisely/bigdata/sample/spark/MultipassGeocodingTester.scala
+++ b/multipass-geocoding/src/test/scala/com/precisely/bigdata/sample/spark/MultipassGeocodingTester.scala
@@ -15,9 +15,12 @@ package com.precisely.bigdata.sample.spark
 
 import java.util.logging.{ConsoleHandler, Level, Logger}
 
+import org.junit.runner.RunWith
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class MultipassGeocodingTester extends AnyFunSuite with BeforeAndAfterAll {
 
   private val parquetLogger = Logger.getLogger("org.apache.parquet") //holding on to logger to persist log level changes


### PR DESCRIPTION
In order to support scala 2.12 we need a version of scalatest that is at least 3.0.0 Scalatest made many breaking changes when going from 2.x to 3.x. 